### PR TITLE
fix: Added missing extension

### DIFF
--- a/configs/webpack.native.config.js
+++ b/configs/webpack.native.config.js
@@ -17,7 +17,7 @@ const widgetConfig = {
         libraryTarget: "commonjs2"
     },
     resolve: {
-        extensions: [".js", ".jsx", ".ts", ".tsx"],
+        extensions: [".native.js", ".js", ".jsx", ".ts", ".tsx"],
         alias: {
             "tests": `${variables.path}/tests`
         }


### PR DESCRIPTION
Allow compilation with libraries that use .native.js

Otherwise uncompiled source code ends up in the bundle

Example: https://github.com/kmagiera/react-native-screens/blob/master/src/screens.native.js