### PR TITLE
Production should not have source map

### DIFF
--- a/configs/webpack.config.prod.js
+++ b/configs/webpack.config.prod.js
@@ -11,7 +11,7 @@ const name = widgetName.toLowerCase();
 
 const prodConfig = {
     mode: "production",
-    devtool: "source-map",
+    devtool: false,
     plugins: [
         new ExtractTextPlugin({
             filename: `./widgets/${packagePath}/${name}/ui/${widgetName}.css`


### PR DESCRIPTION
Dear Widgets Team.

We need to prevent source map generation for CSS files. When not prevented the the `release` script will create a CSS file, that will be bundled in widgets.css.

As a result the there will be error logged, to find the sourcemap, which is not bundled, because the widget.css is a simple concatenation of all widgets CSS files. 

![image](https://user-images.githubusercontent.com/6724749/76500451-dc01a000-6440-11ea-966a-e1056fbe5f36.png)

Maybe there is a better way, so the source map of the JS files is persisted, and only prevent CSS map to be generated, though the suggested posted here https://github.com/webpack-contrib/extract-text-webpack-plugin/issues/587 did not fixed this :(

Cheers, Andries